### PR TITLE
got everytihng running so far; mount still does not show up in host

### DIFF
--- a/kubernetes/quobyte-complete/client-ds-debug.yaml
+++ b/kubernetes/quobyte-complete/client-ds-debug.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: client
+  name: client-debug
   namespace: quobyte
 spec:
   template:
@@ -26,10 +26,12 @@ spec:
             else
               mkdir -p ${QUOBYTE_MOUNT_POINT}
             fi
-            /bin/nsenter --target=1 --wd=. \
-              --mount -- lib/ld-linux-x86-64.so.2 \
-              --library-path ./lib \
-            ./bin/mount.quobyte -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/${VOLUME} ${QUOBYTE_MOUNT_POINT}
+            #/bin/nsenter --target=1 --wd=. \
+            #  --mount --  /lib/ld-linux-x86-64.so.2 \
+            #  /lib/libmicrohttpd.so.10 \
+            #  --library-path ./lib \
+            #./bin/mount.quobyte -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/${VOLUME} ${QUOBYTE_MOUNT_POINT}
+            /bin/sleep 3600
         securityContext:
           privileged: true
         env:

--- a/kubernetes/quobyte-complete/client-ds.yaml
+++ b/kubernetes/quobyte-complete/client-ds.yaml
@@ -11,12 +11,14 @@ spec:
     spec:
       containers:
       - name: quobyte-client
-        image: quay.io/sttts/quobyte-client-nsenter:1.2.10
+        image: quay.io/quobyte/quobyte-client:1.2.10
         command:
           - /bin/sh
           - -xec
           - |
-            ADDR=$(echo $(getent hosts ${QUOBYTE_REGISTRY} | awk '{print $1":7866"}') | tr ' ' ,)
+            #ADDR=$(echo $(getent hosts ${QUOBYTE_REGISTRY} | awk '{print $1":7866"}') | tr ' ' ,)
+            ADDR=$(echo $(nslookup registry.quobyte.cluster.local | grep -v 10.100.0.10 | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7866"}') | tr ' ' ,)
+            echo "ADDR is $ADDR"
             VOLUME=$(basename ${QUOBYTE_MOUNT_POINT})
             touch /rootfs/etc/fuse.conf
             if cut -d" " -f2 /etc/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
@@ -24,9 +26,11 @@ spec:
             else
               mkdir -p ${QUOBYTE_MOUNT_POINT}
             fi
-            /bin/nsenter --target=1 --wd=. --mount -- \
-              lib/ld-linux-x86-64.so.2 --library-path ./lib \
-              ./bin/mount.quobyte -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/${VOLUME} ${QUOBYTE_MOUNT_POINT}
+            #/bin/nsenter --target=1 --wd=. \
+            #  --mount --  /lib/ld-linux-x86-64.so.2 \
+            #  /lib/libmicrohttpd.so.10 \
+            #  --library-path ./lib \
+            ./bin/mount.quobyte -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/${VOLUME} ${QUOBYTE_MOUNT_POINT}
         securityContext:
           privileged: true
         env:
@@ -35,7 +39,7 @@ spec:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
-            value: registry
+            value: registry.quobyte.cluster.local
           - name: QUOBYTE_MOUNT_POINT
             value: /storage/cluster
         ports:
@@ -45,7 +49,7 @@ spec:
             protocol: TCP
         volumeMounts:
           - name: storage
-            mountPath: /storage
+            mountPath: storage
           - name: rootfs
             mountPath: /rootfs
         imagePullPolicy: Always

--- a/kubernetes/quobyte-complete/data-ds.yaml
+++ b/kubernetes/quobyte-complete/data-ds.yaml
@@ -45,7 +45,7 @@ spec:
             exec /bin/bash -x /opt/main.sh
         volumeMounts:
           - name: devices
-            mountPath: /devices
+            mountPath: /devices/data
         resources:
           requests:
             memory: "512Mi"
@@ -53,4 +53,4 @@ spec:
       volumes:
       - name: devices
         hostPath:
-          path: /mnt
+          path: /mnt/data

--- a/kubernetes/quobyte-complete/metadata-ds.yaml
+++ b/kubernetes/quobyte-complete/metadata-ds.yaml
@@ -8,11 +8,11 @@ spec:
     metadata:
       labels:
         role: metadata
-        version: 1.2.10
+        version: 1.2.16
     spec:
       containers:
       - name: quobyte-metadata
-        image: quay.io/quobyte/quobyte-server:1.2.10
+        image: quay.io/quobyte/quobyte-server:1.2.16
         securityContext:
           privileged: true
         env:

--- a/kubernetes/quobyte-complete/metadata-ds.yaml
+++ b/kubernetes/quobyte-complete/metadata-ds.yaml
@@ -45,7 +45,7 @@ spec:
             exec /bin/bash -x /opt/main.sh
         volumeMounts:
           - name: devices
-            mountPath: /devices
+            mountPath: /devices/metadata
         resources:
           limits:
             memory: "512Mi"
@@ -53,4 +53,4 @@ spec:
       volumes:
       - name: devices
         hostPath:
-          path: /mnt
+          path: /mnt/metadata

--- a/kubernetes/quobyte-complete/registry-bootstrap-pod.yaml
+++ b/kubernetes/quobyte-complete/registry-bootstrap-pod.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     role: registry
     bootstrap: "true"
-    version: 1.2.10
+    version: 1.2.12
   name: registry-bootstrap
   namespace: quobyte
 spec:
   containers:
     - name: quobyte-registry
-      image: quay.io/quobyte/quobyte-server:1.2.10
+      image: quay.io/quobyte/quobyte-server:1.2.12
       securityContext:
         privileged: true
       env:
@@ -45,7 +45,7 @@ spec:
           protocol: TCP
       volumeMounts:
         - name: devices
-          mountPath: /devices
+          mountPath: /devices/dev1
       command:
         - /bin/bash
         - -xec

--- a/kubernetes/quobyte-complete/registry-rc.yaml
+++ b/kubernetes/quobyte-complete/registry-rc.yaml
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: devices
-              mountPath: /devices
+              mountPath: /devices/dev1
           command:
             - /bin/bash
             - -xec

--- a/kubernetes/quobyte-complete/registry-rc.yaml
+++ b/kubernetes/quobyte-complete/registry-rc.yaml
@@ -9,13 +9,13 @@ spec:
     metadata:
       labels:
         role: registry
-        version: 1.2.10
+        version: 1.2.16
       name: registry-bootstrap
       namespace: quobyte
     spec:
       containers:
         - name: quobyte-registry
-          image: quay.io/quobyte/quobyte-server:1.2.10
+          image: quay.io/quobyte/quobyte-server:1.2.16
           securityContext:
             privileged: true
           env:

--- a/kubernetes/quobyte-complete/webconsole-rc.yaml
+++ b/kubernetes/quobyte-complete/webconsole-rc.yaml
@@ -8,11 +8,11 @@ spec:
     metadata:
       labels:
         role: webconsole
-        version: 1.2.10
+        version: 1.2.16
     spec:
       containers:
       - name: quobyte-webconsole
-        image: quay.io/quobyte/quobyte-server:1.2.10
+        image: quay.io/quobyte/quobyte-server:1.2.16
         env:
           - name: QUOBYTE_SERVICE
             value: "webconsole"
@@ -46,7 +46,7 @@ spec:
             memory: "300Mi"
             cpu: "100m"
       - name: quobyte-api
-        image: quay.io/quobyte/quobyte-server:1.2.10
+        image: quay.io/quobyte/quobyte-server:1.2.16
         env:
           - name: QUOBYTE_SERVICE
             value: api


### PR DESCRIPTION
The main problem seems to be that with a recent change of quobyte the way devices are scanned has changed so that the one level depth subdirectories are not scanned anymore for marker files. 
So the bind mounts have to point to the device directly in order to make registry, metadata and data pods run properly. Thanks to the guys at quobyte for helping me to solve this.

Next I had a problem with the client pot not finding some shared libs. After some fiddeling around I skipped the nsenter approach and use the quobyte-client docker image for this. 

This is working and the client is running, however the shared mount works only in the container.

Issues remaining:
- with the new mount points device files for metadata and data are probably not created 
- cluster file system is working only inside the pod, not on the host.
