### PR TITLE
fixes + documentation for client deployments

### DIFF
--- a/client_quick_setup.md
+++ b/client_quick_setup.md
@@ -20,7 +20,7 @@ $ systemctl daemon-reload && systemctl restart docker
 ```
 
 ## Client setup
-This guide assumes that you have a dedicated Quobyte instance running and you
+This guide assumes that you have a dedicated Quobyte server running and you
 want to provide access to Quobyte volumes to pods running in Kubernetes.
 
 To access a Quobyte volume a pod has to run on a Kubernetes node which has a
@@ -67,6 +67,10 @@ $ kubectl label nodes <node-1> <node-n> quobyte_client="true"
 
 When the client pod is up and running, you should see a mount point on the Kubernetes node
 at `/var/lib/kubelet/plugins/kubernetes.io~quobyte`.
+
+Please note: Only those nodes labeled with the 'quobyte_client' label and hence
+are running the Quobyte client can provide access to Quobyte storage to other pods
+running on the node.
 
 ##Benchmarking
 

--- a/deploy/client-certificate-ds.yaml
+++ b/deploy/client-certificate-ds.yaml
@@ -15,70 +15,19 @@ spec:
         prometheus.io/port: '55000'
       labels:
         role: client
-        version: "2.0.pre"
+        version: "2"
     spec:
-      #serviceAccountName: quobyteclientsrv
       containers:
       - name: quobyte-client
         image: quay.io/quobyte/quobyte-client:2
         imagePullPolicy: Always
-        # NOTE(kaisers): The weird if check before mkdir -p is required to not hang on a stale mount
-        command:
-          - /bin/sh
-          - -xec
-          - |
-            if [[ ! -f /etcfs/fuse.conf ]]; then
-              echo "Copy fuse config to host"
-              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
-            fi
-            if [[ $(grep "^[^#]" /etcfs/fuse.conf | grep -c "user_allow_other") -eq 0 ]]; then
-              echo "user_allow_other" >> /etcfs/fuse.conf
-            fi
-            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
-              umount ${QUOBYTE_MOUNT_POINT}
-            else
-              if ! [[ $(ls `dirname ${QUOBYTE_MOUNT_POINT}`|egrep "^`basename ${QUOBYTE_MOUNT_POINT}`$") ]]; then
-                echo "mount point ${QUOBYTE_MOUNT_POINT} does not exist, creating it..."
-                mkdir -p ${QUOBYTE_MOUNT_POINT}
-              fi
-            fi
-
-            # set the mount point immutable. As long as mount.quobyte does not run,
-            # other processes cannot write data to this dir.
-            chattr +i ${QUOBYTE_MOUNT_POINT}
-
-            if echo ${QUOBYTE_REGISTRY} | grep -q ","; then
-              # registries are outside the k8s cluster, pass through and DNS lookup later
-              ADDR=${QUOBYTE_REGISTRY}
-            else
-              # Currently, within the nsenter, k8s dns names cannot be resolved.
-              ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7861"}') | tr ' ' ,)
-            fi
-            echo "QUOBYTE_REGISTRY: ${ADDR}"
-            mkdir -p /root/.quobyte
-            cp /quobytecert/client.cfg /root/.quobyte/client.cfg
-            /bin/nsenter -t 1 --wd=. -m -- \
-              lib/ld-linux-x86-64.so.2 \
-              --library-path ./lib \
-            ./bin/mount.quobyte \
-              -c ./root/.quobyte/client.cfg \
-              --hostname ${NODENAME} \
-              --allow-usermapping-in-volumename \
-              --http-port 55000 \
-              -f \
-              -l /dev/stdout \
-              -d ${QUOBYTE_CLIENT_LOG_LEVEL} \
-              ${OPTS} \
-              ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
-        securityContext:
-          privileged: true
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
             value: registry.quobyte
           - name: QUOBYTE_MOUNT_POINT
-            # Note(kaisers): the mount point has to be a subdir of the volume(Mount)
+            # Note that the mount point has to be a subdir of the volume(Mount)
             value: /var/lib/kubelet/plugins/kubernetes.io~quobyte
           - name: NODENAME
             valueFrom:
@@ -100,9 +49,64 @@ spec:
           httpGet:
             port: 55000
             path: /
+        command:
+          - /bin/sh
+          - -xec
+          - |
+            if [[ ! -f /etcfs/fuse.conf ]]; then
+              echo "Copy fuse config to host"
+              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
+            fi
+            if [[ $(grep "^[^#]" /etcfs/fuse.conf | grep -c "user_allow_other") -eq 0 ]]; then
+              echo "user_allow_other" >> /etcfs/fuse.conf
+            fi
+            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
+              echo "found existing mount point on host. Trying to umount ${QUOBYTE_MOUNT_POINT}"
+              /bin/nsenter -t 1 --wd=. -m -- lib/ld-linux-x86-64.so.2 --library-path ./lib ./bin/umount -f ${QUOBYTE_MOUNT_POINT}
+            else
+              if ! [[ $(ls `dirname ${QUOBYTE_MOUNT_POINT}`|egrep "^`basename ${QUOBYTE_MOUNT_POINT}`$") ]]; then
+                echo "mount point ${QUOBYTE_MOUNT_POINT} does not exist, creating it..."
+                mkdir -p ${QUOBYTE_MOUNT_POINT}
+              fi
+            fi
+
+            # set the mount point immutable. As long as mount.quobyte does not run,
+            # other processes cannot write data to this dir.
+            chattr +i ${QUOBYTE_MOUNT_POINT}
+
+            # Until k8s mountPropagation is stable, nsenter is used for the client
+            # to mount Quobyte into the host's mount namespace. By using nsenter, the client process
+            # will also use the host's dns resolve mechanisms, which most probably will not include
+            # the k8s internal name resolution. So the client is not able to resolve k8s internal 'registry.quobyte' anymore.
+            # Hence, for k8s internal Quobyte clusters, we need to pre-resolve the current ips, and let the client
+            # work with ips and not dns names.
+            if [ "$QUOBYTE_REGISTRY" == "registry" ] || [ "$QUOBYTE_REGISTRY" == "registry.quobyte" ] ; then
+              ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7861"}') | tr ' ' ,)
+              echo "Assuming to connect to k8s hosted Quobyte cluster. Resolved DNS to: '$ADDR'"
+            else
+              ADDR=${QUOBYTE_REGISTRY}
+              echo "Assuming to connect to an external Quobyte cluster. Client will resolve DNS for: '$ADDR'"
+            fi
+            mkdir -p /root/.quobyte
+            cp /quobytecert/client.cfg /root/.quobyte/client.cfg
+            /bin/nsenter -t 1 --wd=. -m -- \
+              lib/ld-linux-x86-64.so.2 \
+              --library-path ./lib \
+            ./bin/mount.quobyte \
+              -c ./root/.quobyte/client.cfg \
+              --hostname ${NODENAME} \
+              --allow-usermapping-in-volumename \
+              --http-port 55000 \
+              -f \
+              -l /dev/stdout \
+              -d ${QUOBYTE_CLIENT_LOG_LEVEL} \
+              ${OPTS} \
+              ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
+        securityContext:
+          privileged: true
         volumeMounts:
           - name: k8s-plugin-dir
-            mountPath: /var/lib/kubelet/plugins/kubernetes.io~quobyte
+            mountPath: /var/lib/kubelet/plugins/
           - name: etcfs
             mountPath: /etcfs
           - name: configs
@@ -117,7 +121,7 @@ spec:
       volumes:
       - name: k8s-plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/kubernetes.io~quobyte
+          path: /var/lib/kubelet/plugins/
       - name: etcfs
         hostPath:
           path: /etc

--- a/deploy/client-ds.yaml
+++ b/deploy/client-ds.yaml
@@ -17,69 +17,17 @@ spec:
         role: client
         version: "2"
     spec:
-      #serviceAccountName: quobyteclientsrv
       containers:
       - name: quobyte-client
         image: quay.io/quobyte/quobyte-client:2
         imagePullPolicy: Always
-        # NOTE(kaisers): The weird if check before mkdir -p is required to not hang on a stale mount
-        command:
-          - /bin/sh
-          - -xec
-          - |
-            if [[ ! -f /etcfs/fuse.conf ]]; then
-              echo "Copy fuse config to host"
-              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
-            fi
-            if [[ $(grep "^[^#]" /etcfs/fuse.conf | grep -c "user_allow_other") -eq 0 ]]; then
-              echo "user_allow_other" >> /etcfs/fuse.conf
-            fi
-            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
-              umount ${QUOBYTE_MOUNT_POINT}
-            else
-              if ! [[ $(ls `dirname ${QUOBYTE_MOUNT_POINT}`|egrep "^`basename ${QUOBYTE_MOUNT_POINT}`$") ]]; then
-                echo "mount point ${QUOBYTE_MOUNT_POINT} does not exist, creating it..."
-                mkdir -p ${QUOBYTE_MOUNT_POINT}
-              fi
-            fi
-
-            # set the mount point immutable. As long as mount.quobyte does not run,
-            # other processes cannot write data to this dir.
-            chattr +i ${QUOBYTE_MOUNT_POINT}
-
-            # convert QUOBYTE_REGISTRY to IPs
-            # QUOBYTE_REGISTRY is a comma separated value of registry endpoints
-            # e.g., s1.example.com:5681,s2.example.com:5681,s3.example.com:5681
-            # or it can be a single value: s.example.com:5681
-            registry_ips=
-
-            IFS=','
-            for endpoint in $QUOBYTE_REGISTRY; do
-                name=$(echo $endpoint | awk '{split($0,a,":"); print a[1]}')
-                port=$(echo $endpoint | awk '{split($0,a,":"); print a[2]}')
-                ip=$(nslookup $name | grep $name -A2 | grep Address | cut -d':' -f2 | awk '{print $1}')
-                registry_ips="$ip:$port $registry_ips"
-            done
-            unset IFS
-
-            ADDR=$(echo $registry_ips | tr ' ' ',')
-            echo "QUOBYTE_REGISTRY: ${ADDR}"
-
-            /bin/nsenter -t 1 --wd=. -m -- \
-              lib/ld-linux-x86-64.so.2 \
-              --library-path ./lib \
-            ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
-              --http-port 55000 -f -l /dev/stdout -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} \
-              ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
-        securityContext:
-          privileged: true
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
             value: registry.quobyte
           - name: QUOBYTE_MOUNT_POINT
-            # Note(kaisers): the mount point has to be a subdir of the volume(Mount)
+            # Note that the mount point has to be a subdir of the volume(Mount)
             value: /var/lib/kubelet/plugins/kubernetes.io~quobyte
           - name: NODENAME
             valueFrom:
@@ -101,9 +49,56 @@ spec:
           httpGet:
             port: 55000
             path: /
+        command:
+          - /bin/sh
+          - -xec
+          - |
+            if [[ ! -f /etcfs/fuse.conf ]]; then
+              echo "Copy fuse config to host"
+              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
+            fi
+            if [[ $(grep "^[^#]" /etcfs/fuse.conf | grep -c "user_allow_other") -eq 0 ]]; then
+              echo "user_allow_other" >> /etcfs/fuse.conf
+            fi
+            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
+              echo "found existing mount point on host. Trying to umount ${QUOBYTE_MOUNT_POINT}"
+              /bin/nsenter -t 1 --wd=. -m -- lib/ld-linux-x86-64.so.2 --library-path ./lib ./bin/umount -f ${QUOBYTE_MOUNT_POINT}
+            else
+              if ! [[ $(ls `dirname ${QUOBYTE_MOUNT_POINT}`|egrep "^`basename ${QUOBYTE_MOUNT_POINT}`$") ]]; then
+                echo "mount point ${QUOBYTE_MOUNT_POINT} does not exist, creating it..."
+                mkdir -p ${QUOBYTE_MOUNT_POINT}
+              fi
+            fi
+
+            # set the mount point immutable. As long as mount.quobyte does not run,
+            # other processes cannot write data to this dir.
+            chattr +i ${QUOBYTE_MOUNT_POINT}
+
+            # Until k8s mountPropagation is stable, nsenter is used for the client
+            # to mount Quobyte into the host's mount namespace. By using nsenter, the client process
+            # will also use the host's dns resolve mechanisms, which most probably will not include
+            # the k8s internal name resolution. So the client is not able to resolve k8s internal 'registry.quobyte' anymore.
+            # Hence, for k8s internal Quobyte clusters, we need to pre-resolve the current ips, and let the client
+            # work with ips and not dns names.
+            if [ "$QUOBYTE_REGISTRY" == "registry" ] || [ "$QUOBYTE_REGISTRY" == "registry.quobyte" ] ; then
+              ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7861"}') | tr ' ' ,)
+              echo "Assuming to connect to k8s hosted Quobyte cluster. Resolved DNS to: '$ADDR'"
+            else
+              ADDR=${QUOBYTE_REGISTRY}
+              echo "Assuming to connect to an external Quobyte cluster. Client will resolve DNS for: '$ADDR'"
+            fi
+
+            /bin/nsenter -t 1 --wd=. -m -- \
+              lib/ld-linux-x86-64.so.2 \
+              --library-path ./lib \
+            ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
+              --http-port 55000 -f -l /dev/stdout -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} \
+              ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
+        securityContext:
+          privileged: true
         volumeMounts:
           - name: k8s-plugin-dir
-            mountPath: /var/lib/kubelet/plugins/kubernetes.io~quobyte
+            mountPath: /var/lib/kubelet/plugins/
           - name: etcfs
             mountPath: /etcfs
         lifecycle:
@@ -116,7 +111,7 @@ spec:
       volumes:
       - name: k8s-plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/kubernetes.io~quobyte
+          path: /var/lib/kubelet/plugins/
       - name: etcfs
         hostPath:
           path: /etc

--- a/operator/deploy/client.yaml
+++ b/operator/deploy/client.yaml
@@ -26,58 +26,11 @@ spec:
       - name: quobyte-client
         image: quay.io/quobyte/quobyte-client:2
         imagePullPolicy: Always
-        # The 'if' check before mkdir -p is required to not hang on a stale mount
-        command:
-          - /bin/sh
-          - -xec
-          - |
-            if [[ ! -f /etcfs/fuse.conf ]]; then
-              echo "Copy fuse config to host"
-              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
-            fi
-            if [[ $(grep "^[^#]" /etcfs/fuse.conf | grep -c "user_allow_other") -eq 0 ]]; then
-              echo "user_allow_other" >> /etcfs/fuse.conf
-            fi
-            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
-              echo "found existing mount point. Please unmount ${QUOBYTE_MOUNT_POINT} first."
-              # /bin/nsenter -t 1 --wd=. -m -- lib/ld-linux-x86-64.so.2 --library-path ./lib ./bin/umount -f ${QUOBYTE_MOUNT_POINT}
-            else
-              if ! [[ $(ls `dirname ${QUOBYTE_MOUNT_POINT}`|egrep "^`basename ${QUOBYTE_MOUNT_POINT}`$") ]]; then
-                echo "mount point ${QUOBYTE_MOUNT_POINT} does not exist, creating it..."
-                mkdir -p ${QUOBYTE_MOUNT_POINT}
-              fi
-            fi
-
-            # set the mount point immutable. As long as mount.quobyte does not run,
-            # other processes cannot write data to this dir.
-            chattr +i ${QUOBYTE_MOUNT_POINT}
-
-            if echo ${QUOBYTE_REGISTRY} | grep -q ","; then
-              # registries are outside the k8s cluster, pass through and DNS lookup later
-              ADDR=${QUOBYTE_REGISTRY}
-            else
-              # Currently, within the nsenter, k8s dns names cannot be resolved.
-              ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7861"}') | tr ' ' ,)
-            fi
-            echo "Resolved QUOBYTE_REGISTRY: ${ADDR}"
-
-            /bin/nsenter -t 1 --wd=. -m -- lib/ld-linux-x86-64.so.2 --library-path ./lib \
-            ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
-              --http-port 55000 -f -l /dev/stdout -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} \
-              ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
-        securityContext:
-          privileged: true
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
-            valueFrom:
-              configMapKeyRef:
-                name: quobyte-config
-                key: client.log_level
+            value: INFO
           - name: QUOBYTE_REGISTRY
-            valueFrom:
-              configMapKeyRef:
-                name: quobyte-config
-                key: client.registry
+            value: registry.quobyte
           - name: QUOBYTE_MOUNT_POINT
             # Note that the mount point has to be a subdir of the volume(Mount)
             value: /var/lib/kubelet/plugins/kubernetes.io~quobyte
@@ -101,9 +54,56 @@ spec:
           httpGet:
             port: 55000
             path: /
+        command:
+          - /bin/sh
+          - -xec
+          - |
+            if [[ ! -f /etcfs/fuse.conf ]]; then
+              echo "Copy fuse config to host"
+              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
+            fi
+            if [[ $(grep "^[^#]" /etcfs/fuse.conf | grep -c "user_allow_other") -eq 0 ]]; then
+              echo "user_allow_other" >> /etcfs/fuse.conf
+            fi
+            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
+              echo "found existing mount point on host. Trying to umount ${QUOBYTE_MOUNT_POINT}"
+              /bin/nsenter -t 1 --wd=. -m -- lib/ld-linux-x86-64.so.2 --library-path ./lib ./bin/umount -f ${QUOBYTE_MOUNT_POINT}
+            else
+              if ! [[ $(ls `dirname ${QUOBYTE_MOUNT_POINT}`|egrep "^`basename ${QUOBYTE_MOUNT_POINT}`$") ]]; then
+                echo "mount point ${QUOBYTE_MOUNT_POINT} does not exist, creating it..."
+                mkdir -p ${QUOBYTE_MOUNT_POINT}
+              fi
+            fi
+
+            # set the mount point immutable. As long as mount.quobyte does not run,
+            # other processes cannot write data to this dir.
+            chattr +i ${QUOBYTE_MOUNT_POINT}
+
+            # Until k8s mountPropagation is stable, nsenter is used for the client
+            # to mount Quobyte into the host's mount namespace. By using nsenter, the client process
+            # will also use the host's dns resolve mechanisms, which most probably will not include
+            # the k8s internal name resolution. So the client is not able to resolve k8s internal 'registry.quobyte' anymore.
+            # Hence, for k8s internal Quobyte clusters, we need to pre-resolve the current ips, and let the client
+            # work with ips and not dns names.
+            if [ "$QUOBYTE_REGISTRY" == "registry" ] || [ "$QUOBYTE_REGISTRY" == "registry.quobyte" ] ; then
+              ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7861"}') | tr ' ' ,)
+              echo "Assuming to connect to k8s hosted Quobyte cluster. Resolved DNS to: '$ADDR'"
+            else
+              ADDR=${QUOBYTE_REGISTRY}
+              echo "Assuming to connect to an external Quobyte cluster. Client will resolve DNS for: '$ADDR'"
+            fi
+
+            /bin/nsenter -t 1 --wd=. -m -- \
+              lib/ld-linux-x86-64.so.2 \
+              --library-path ./lib \
+            ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
+              --http-port 55000 -f -l /dev/stdout -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} \
+              ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
+        securityContext:
+          privileged: true
         volumeMounts:
           - name: k8s-plugin-dir
-            mountPath: /var/lib/kubelet/plugins/kubernetes.io~quobyte
+            mountPath: /var/lib/kubelet/plugins/
           - name: etcfs
             mountPath: /etcfs
         lifecycle:
@@ -116,7 +116,7 @@ spec:
       volumes:
       - name: k8s-plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/kubernetes.io~quobyte
+          path: /var/lib/kubelet/plugins/
       - name: etcfs
         hostPath:
           path: /etc

--- a/using_quobyte_volumes.md
+++ b/using_quobyte_volumes.md
@@ -7,7 +7,7 @@ the QuobyteVolumeSource like in `deploy/example-pod.yaml`
 volumes:
 - name: quobytevolume
   quobyte:
-    registry: LBIP:7861
+    registry: ignored:7861 # Unused string required for API compatibility
     volume: testVolume
     readOnly: false
     user: username
@@ -74,7 +74,7 @@ spec:
     - ReadWriteOnce
   storageClassName: "base"
   quobyte:
-    registry: LBIP:7861
+    registry: ignored:7861 # Unused string required for API compatibility
     volume: test
     readOnly: false
     user: username
@@ -87,6 +87,9 @@ $ kubectl -n quobyte create -f volumes/pv.yaml
 
 For dynamic provisioning, a StorageClass is created, which manages the
 lifecycle of Quobyte volumes.
+Each provisioner is bound to a Quobyte tenant, which is specified in the 'quobyteTenant' field.
+The UUID of the tenant can be found in the Webconsole.
+For Kubernetes > 1.10, the 'quobyteTenant' can specify the name of the tenant.
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -102,7 +105,7 @@ parameters:
     user: "username"
     group: "groupname"
     quobyteConfig: "BASE"
-    quobyteTenant: "DEFAULT"
+    quobyteTenant: "uuid of tenant"
     createQuota: "False"
 ```
 
@@ -135,7 +138,7 @@ Quobyte supports multiple tenants and provides a secure mapping of containers to
 For a longer read, please see the article on the Quobyte blog:
 [The State of Secure Storage Access in Container Infrastructures](https://www.quobyte.com/blog/2017/03/17/the-state-of-secure-storage-access-in-container-infrastructures/)
 
-The kubernetes deployments of the Quobyte client use the `--allow-usermapping-in-volumename`, which allows to map all accesses to the
+The Kubernetes deployments of the Quobyte client use the `--allow-usermapping-in-volumename`, which allows to map all accesses to the
 volume to a particular user/group, independent of the accessing user.
 If you specify `user#group@volume_name` instead of just the volumename,
 the Quobyte client will map all storage accesses to the `user:group`.

--- a/volumes/pv.yaml
+++ b/volumes/pv.yaml
@@ -11,6 +11,8 @@ spec:
     - ReadWriteOnce
   storageClassName: "base"
   quobyte:
+    # the registry parameter was an required parameter, but is not used anymore.
+    # It's here for API compatibility.
     registry: ignored:7861
     volume: test
     readOnly: false

--- a/volumes/storageclass.yaml
+++ b/volumes/storageclass.yaml
@@ -11,6 +11,8 @@ parameters:
     user: "root"
     group: "root"
     quobyteConfig: "BASE"
-    quobyteTenant: "My Tenant"
+# For kubernetes < 1.10.2, quobyteTenant needs point to the tenant's uuid.
+# Later versions are able to resolve the tenant's name.
+    quobyteTenant: "<uuid of tenant>"
     createQuota: "False"
 reclaimPolicy: Retain


### PR DESCRIPTION
improved documentation

fixed hassle with mountpoints and lifecycles.

container will check if the  /var/lib/kubelet/plugins/kubernetes.io~quobyte is mounted in the host's mount namespace. Then use nsenter to call umount in the host's namespace.

Clarified and fixed dns resolving for clusters which run inside of k8s or external.