### PR TITLE
Change mount.quobyte path from /bin to /usr/bin

### DIFF
--- a/deploy/client-certificate-ds.yaml
+++ b/deploy/client-certificate-ds.yaml
@@ -97,7 +97,7 @@ spec:
             /bin/nsenter -t 1 --wd=. -m -- \
               lib/ld-linux-x86-64.so.2 \
               --library-path ./lib \
-            ./bin/mount.quobyte \
+              /usr/bin/mount.quobyte \
               -c ./root/.quobyte/client.cfg \
               --hostname ${NODENAME} \
               --allow-usermapping-in-volumename \

--- a/deploy/client-ds.yaml
+++ b/deploy/client-ds.yaml
@@ -96,7 +96,7 @@ spec:
             /bin/nsenter -t 1 --wd=. -m -- \
               lib/ld-linux-x86-64.so.2 \
               --library-path ./lib \
-            ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
+              /usr/bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
               --http-port 55000 -f -l /dev/stdout -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} \
               ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
 

--- a/operator/deploy/client.yaml
+++ b/operator/deploy/client.yaml
@@ -108,7 +108,7 @@ spec:
             /bin/nsenter -t 1 --wd=. -m -- \
               lib/ld-linux-x86-64.so.2 \
               --library-path ./lib \
-            ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
+              /usr/bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename \
               --http-port 55000 -f -l /dev/stdout -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} \
               ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
         securityContext:


### PR DESCRIPTION
mount.quobyte used to be under /bin and it is moved to /usr/bin
but the change is not made in kubernetes files leading to client
crash on kubernetes. This patch fixes the path issue.