### PR TITLE
Adding additional lazy umounts if forced is not successful

### DIFF
--- a/deploy/client-ds.yaml
+++ b/deploy/client-ds.yaml
@@ -62,7 +62,9 @@ spec:
             fi
             if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
               echo "found existing mount point on host. Trying to umount ${QUOBYTE_MOUNT_POINT}"
-              /bin/nsenter -t 1 -m -- /bin/umount -f ${QUOBYTE_MOUNT_POINT}
+              if ! /bin/nsenter -t 1 -m -- /bin/umount -f ${QUOBYTE_MOUNT_POINT}; then
+                /bin/nsenter -t 1 -m -- /bin/umount -l ${QUOBYTE_MOUNT_POINT}
+              fi
               sleep 1 # give os the chance to clean up everything.
             else
               if ! [[ $(ls `dirname ${QUOBYTE_MOUNT_POINT}`|egrep "^`basename ${QUOBYTE_MOUNT_POINT}`$") ]]; then
@@ -110,7 +112,13 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/bash", "-xc", "/bin/nsenter -t 1 -m -- /bin/umount -f ${QUOBYTE_MOUNT_POINT}"]
+              command:
+                - /bin/bash
+                - -xc
+                - |
+                  if ! /bin/nsenter -t 1 -m -- /bin/umount -f ${QUOBYTE_MOUNT_POINT}; then
+                    /bin/nsenter -t 1 -m -- /bin/umount -l ${QUOBYTE_MOUNT_POINT}
+                  fi
       hostPID: true
       nodeSelector:
         quobyte_client: "true"


### PR DESCRIPTION
During pod crash loop testing i occasionally met busy mount points that could not be umounted with the --force option. This adds a umount --lazy should the --force umount not work during preStop hook or startup script.