### PR TITLE
client-ds: persist minidumps and upload them automatically

### DIFF
--- a/deploy/client-certificate-ds.yaml
+++ b/deploy/client-certificate-ds.yaml
@@ -101,6 +101,7 @@ spec:
               -c ./root/.quobyte/client.cfg \
               --hostname ${NODENAME} \
               --allow-usermapping-in-volumename \
+              --minidump-path /tmp/minidumps --allow-minidump-upload \
               --http-port 55000 \
               -f \
               -l /dev/stdout \
@@ -116,6 +117,8 @@ spec:
             mountPath: /etcfs
           - name: configs
             mountPath: /quobytecert
+          - name: minidumps-dir
+            mountPath: /tmp/minidumps
         lifecycle:
           preStop:
             exec:
@@ -130,6 +133,9 @@ spec:
       - name: etcfs
         hostPath:
           path: /etc
+      - name: minidumps-dir
+        hostPath:
+          path: /var/lib/quobyte/.minidumps
       - name: configs
         secret:
           defaultMode: 420

--- a/deploy/client-ds.yaml
+++ b/deploy/client-ds.yaml
@@ -72,6 +72,7 @@ spec:
               /usr/bin/mount.quobyte --hostname ${NODENAME} \
                 --allow-usermapping-in-volumename --http-port 55000 -f \
                 -d ${QUOBYTE_CLIENT_LOG_LEVEL} -l /dev/stdout ${OPTS} \
+                --minidump-path /tmp/minidumps --allow-minidump-upload \
                 ${QUOBYTE_REGISTRY}/ ${QUOBYTE_MOUNT_POINT}
             fi
 
@@ -82,6 +83,8 @@ spec:
           - name: k8s-plugin-dir
             mountPath: /mnt
             mountPropagation: Bidirectional
+          - name: minidumps-dir
+            mountPath: /tmp/minidumps
         lifecycle:
           preStop:
             exec:
@@ -92,3 +95,6 @@ spec:
       - name: k8s-plugin-dir
         hostPath:
           path: /var/lib/kubelet/plugins/
+      - name: minidumps-dir
+        hostPath:
+          path: /var/lib/quobyte/.minidumps


### PR DESCRIPTION
Maps /var/lib/quobyte/.minidumps into the pod and uses it to store
minidumps. Existing minidumps are automatically uploaded to Quobyte by
the Quobyte client.